### PR TITLE
Support general purpose syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 
 DSL for text-based Pomodoro Timer
 
+## Syntax
+
+```
+- [ ] [(25m✍️ 5m☕️)4] xxx
+```
+
+- `1h|1m|1s` Timer time (hours or minutes or seconds), even `p1` will be 1 minute
+- `...✍️` (Optional) Can add an explanation of what time it is
+- `(...)1` (Optional) Repeat the time in parentheses for the specified number of times, or once if the number is omitted.
+
 ## Used by
 - [Pomodoro Edit for Inkdrop](https://github.com/seachicken/inkdrop-pomodoro-edit)
 - [Pomodoro Edit for VSCode](https://github.com/seachicken/vscode-pomodoro-edit)

--- a/src/pomodoro-edit-core.js
+++ b/src/pomodoro-edit-core.js
@@ -168,7 +168,7 @@ export default class Core {
       stepNos.pop();
     }
 
-    if (timer.timeSec) {
+    if (timer.seconds) {
       const displayStepNos = this._convertToDisplayStepNos(stepNos);
       results.push(() => this._createTimer(timer, callbacks, displayStepNos));
     }
@@ -194,11 +194,11 @@ export default class Core {
       stepNos,
       symbol: timer.symbol,
       promise: new Promise(resolve => {
-        let remainingSec = timer.timeSec;
+        let remainingSec = timer.seconds;
         this._interval = setInterval(() => {
           if (this._isPaused) return;
 
-          callbacks.interval(--remainingSec, timer.timeSec, stepNos, timer.symbol);
+          callbacks.interval(--remainingSec, timer.seconds, stepNos, timer.symbol);
 
           if (remainingSec <= 0) {
             clearInterval(this._interval);

--- a/src/pomodoro-edit-core.js
+++ b/src/pomodoro-edit-core.js
@@ -114,7 +114,7 @@ export default class Core {
     const lines = text.split('\n');
     let lineNumber = 0;
     for (const line of lines) {
-      const found = line.match(/^ *(?:- |\* |)(?!\[x\])(?:\[ \] |)\[(-|)(.+)\] *(.+)/);
+      const found = line.match(/^ *(?:- |\* |)(?!\[x\])(?:\[ \] |)\[(-|)(.+?)\] *(.+)/);
       if (found) {
         const syntax = found[2];
         if (syntax.trim().length === 0) {

--- a/src/syntax-parser.js
+++ b/src/syntax-parser.js
@@ -21,7 +21,7 @@ function parseTokens(tokens) {
 }
 
 function toTimeNode(timeToken) {
-  const time = { timeSec: timeToken.timeMin * 60 };
+  const time = { seconds: timeToken.seconds };
   if (timeToken.symbol) {
     time['symbol'] = timeToken.symbol;
   }

--- a/src/syntax-tokenizer.js
+++ b/src/syntax-tokenizer.js
@@ -1,5 +1,5 @@
 const LOOP_REGEX = /\)(?:\d+|)/;
-const TIME_REGEX = /\d+[ms]/;
+const TIME_REGEX = /\d+[hms]/;
 const P_REGEX = /p\d+/;
 
 export const tokenType = {
@@ -36,12 +36,12 @@ export function tokenize(syntax) {
         const pSyntax = getStrBeforeReservedWord(syntax, i);
         const found = pSyntax.match(P_REGEX);
         if (found) {
-          const timeMin = pSyntax.substring(1, found[0].length);
+          const seconds = pSyntax.substring(1, found[0].length);
           i += found[0].length - 1;
 
           const token = {
             type: tokenType.TIME,
-            timeMin: parseInt(timeMin)
+            seconds: parseInt(seconds) * 60
           };
 
           const symbol = getStrBeforeReservedWord(syntax, i + 1);
@@ -64,11 +64,24 @@ export function tokenize(syntax) {
           i += found[0].length - 1;
 
           const time = timeWithUnit.substring(-1);
-          // TODO: seconds
           const unit = timeWithUnit.substring(time.length - 1);
+
+          let ratio;
+          switch (unit) {
+            case 'h':
+              ratio = 60 * 60;
+              break;
+            case 'm':
+              ratio = 60;
+              break;
+            case 's':
+              ratio = 1;
+              break;
+          }
+
           const token = {
             type: tokenType.TIME,
-            timeMin: parseInt(time)
+            seconds: parseInt(time) * ratio
           };
 
           const symbol = getStrBeforeReservedWord(syntax, i + 1);

--- a/test/pomodoro-edit-core.test.js
+++ b/test/pomodoro-edit-core.test.js
@@ -80,6 +80,33 @@ describe('pomodoro-edit-core', () => {
           }
         });
       });
+
+      test('can find "- [ ] [(p1✍️)1] xxx"', done => {
+        core.findAndStartTimer('- [ ] [(p1✍️)1] xxx', '', {
+          start: actual => {
+            expect(actual.content).toBe('xxx');
+            done();
+          }
+        });
+      });
+
+      test('can find "- [ ] [(1m✍️)1] xxx"', done => {
+        core.findAndStartTimer('- [ ] [(1m✍️)1] xxx', '', {
+          start: actual => {
+            expect(actual.content).toBe('xxx');
+            done();
+          }
+        });
+      });
+
+      test('can find "- [ ] [(1m✍️)1] [a] xxx"', done => {
+        core.findAndStartTimer('- [ ] [(1m✍️)1] [a] xxx', '', {
+          start: actual => {
+            expect(actual.content).toBe('[a] xxx');
+            done();
+          }
+        });
+      });
       
       test('ignores when spaces before content', done => {
         core.findAndStartTimer('[p1]  xxx', '', {

--- a/test/syntax-parser.test.js
+++ b/test/syntax-parser.test.js
@@ -4,16 +4,16 @@ describe('syntax-parser', () => {
 
   test('parse sequential timers', () => {
     expect(parse('p1 p2')).toStrictEqual([
-      { timeSec: 60 },
-      { timeSec: 120 }
+      { seconds: 60 },
+      { seconds: 120 }
     ]);
   });
 
   test('parse loop timers', () => {
     expect(parse('(p1 p2)2')).toStrictEqual([
       { childNodes: [
-          { timeSec: 60 },
-          { timeSec: 120 }
+          { seconds: 60 },
+          { seconds: 120 }
         ], loop: 2
       }
     ]);
@@ -22,11 +22,11 @@ describe('syntax-parser', () => {
   test('parse multiple loop timers', () => {
     expect(parse('(p1)1 (p1)1')).toStrictEqual([
       { childNodes: [
-          { timeSec: 60 }
+          { seconds: 60 }
         ], loop: 1
       },
       { childNodes: [
-          { timeSec: 60 }
+          { seconds: 60 }
         ], loop: 1
       },
     ]);
@@ -35,10 +35,10 @@ describe('syntax-parser', () => {
   test('parse nested loop timers and single timer', () => {
     expect(parse('(p1 (p2 p3)1)2')).toStrictEqual([
       { childNodes: [
-          { timeSec: 60 },
+          { seconds: 60 },
           { childNodes: [
-              { timeSec: 120 },
-              { timeSec: 180 }
+              { seconds: 120 },
+              { seconds: 180 }
             ], loop: 1
           }
         ], loop: 2
@@ -49,7 +49,7 @@ describe('syntax-parser', () => {
   test('parse longest loop timers', () => {
     expect(parse('(p1)')).toStrictEqual([
       { childNodes: [
-          { timeSec: 60 }
+          { seconds: 60 }
         ], loop: 0
       }
     ]);

--- a/test/syntax-tokenizer.test.js
+++ b/test/syntax-tokenizer.test.js
@@ -2,6 +2,40 @@ import { tokenType, tokenize } from '../src/syntax-tokenizer';
 
 describe('syntax-tokenizer', () => {
 
+  test('tokenize the time in hours', () => {
+    expect(tokenize('1h')).toStrictEqual([
+      {
+        type: tokenType.TIME,
+        seconds: 60 * 60 * 1
+      }
+    ]);
+  });
+
+  test('tokenize the time in minutes', () => {
+    expect(tokenize('1m')).toStrictEqual([
+      {
+        type: tokenType.TIME,
+        seconds: 60 * 1
+      }
+    ]);
+
+    expect(tokenize('p1')).toStrictEqual([
+      {
+        type: tokenType.TIME,
+        seconds: 60 * 1
+      }
+    ]);
+  });
+
+  test('tokenize the time in seconds', () => {
+    expect(tokenize('1s')).toStrictEqual([
+      {
+        type: tokenType.TIME,
+        seconds: 1
+      }
+    ]);
+  });
+
   test('tokenize the loop syntax', () => {
     expect(tokenize('(1m 2m)2')).toStrictEqual([
       {
@@ -9,11 +43,11 @@ describe('syntax-tokenizer', () => {
       },
       {
         type: tokenType.TIME,
-        timeMin: 1
+        seconds: 60 * 1
       },
       {
         type: tokenType.TIME,
-        timeMin: 2
+        seconds: 60 * 2
       },
       {
         type: tokenType.CLOSE_PARENTHESIS,
@@ -29,11 +63,11 @@ describe('syntax-tokenizer', () => {
       },
       {
         type: tokenType.TIME,
-        timeMin: 1
+        seconds: 60 * 1
       },
       {
         type: tokenType.TIME,
-        timeMin: 2
+        seconds: 60 * 2
       },
       {
         type: tokenType.CLOSE_PARENTHESIS,
@@ -46,7 +80,7 @@ describe('syntax-tokenizer', () => {
     expect(tokenize('p1✍️')).toStrictEqual([
       {
         type: tokenType.TIME,
-        timeMin: 1,
+        seconds: 60 * 1,
         symbol: '✍️'
       }
     ]);
@@ -59,12 +93,12 @@ describe('syntax-tokenizer', () => {
       },
       {
         type: tokenType.TIME,
-        timeMin: 1,
+        seconds: 60 * 1,
         symbol: '✍️'
       },
       {
         type: tokenType.TIME,
-        timeMin: 2,
+        seconds: 60 * 2,
         symbol: '☕️'
       },
       {

--- a/test/syntax-tokenizer.test.js
+++ b/test/syntax-tokenizer.test.js
@@ -3,6 +3,26 @@ import { tokenType, tokenize } from '../src/syntax-tokenizer';
 describe('syntax-tokenizer', () => {
 
   test('tokenize the loop syntax', () => {
+    expect(tokenize('(1m 2m)2')).toStrictEqual([
+      {
+        type: tokenType.OPEN_PARENTHESIS
+      },
+      {
+        type: tokenType.TIME,
+        timeMin: 1
+      },
+      {
+        type: tokenType.TIME,
+        timeMin: 2
+      },
+      {
+        type: tokenType.CLOSE_PARENTHESIS,
+        loop: 2
+      }
+    ]);
+  });
+
+  test('tokenize the loop syntax', () => {
     expect(tokenize('(p1 p2)2')).toStrictEqual([
       {
         type: tokenType.OPEN_PARENTHESIS


### PR DESCRIPTION
Since "p1 p2" seems like a redundant and meaningless syntax, add a more intuitive syntax.